### PR TITLE
Configure use of keycloak vault with secret `kc-vault`.

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ DataONE services and member repositories.
 DataONE in general is an open source, community project.  We [welcome contributions](./CONTRIBUTING.md) in many forms, including code, graphics, documentation, bug reports, testing, etc.  Use the [DataONE discussions](https://github.com/DataONEorg/dataone/discussions) to discuss these contributions with us.
 
 
+## Credentials
+
+### Provider credentials
+
+When keycloak is authenticating with LDAP for user federation and with providers like ORCID as IdPs, it needs authentication credentials. Keycloak provides a vault feature that supports looking up these credentials from SPI-compliant vault providers, including from plain text files that are mounted in the container. This is useful in kubernetes where the credentials can be added to secrets and then mounted in the container at a known filepath. We configure keystore to use vault credentials mounted from a secret named `kc-vault` for both:
+
+- DataONE LDAP user-federation (use ${vault.ldap} as the config key)
+- DataONE ORCID provider (use ${vault.orcid} as the config key)
+
+Within the Keycloak vault, requests for these vault secrets get mapped to requests for mounted files with the naming pattern `realm_key`, where `realm` is the Keycloak realm for the provider (typically `DataONE` for us), and `key` is the name of the provider key we used to create the secret. To deploy in our typical configuration for DataONE, you should create a secret with two keys, one named `DataONE_ldap` and one named `DataONE_orcid`. Each secret should contain the password value for that provider.  When configuring the `DataONE` realm, we then use `${vault.ldap}` to represent the LDAP password, and `${vault.orcid}` to represent the ORCID provider password. You can create the necessary secret with a command such as:
+
+```
+❯ kubectl create secret generic -n keycloak kc-vault --from-file=DataONE_ldap=./admin/ldap.txt --from-file=DataONE_orcid=./admin/orcid.txt
+secret/kc-vault created
+```
+
 ## Install the dataone-keycloak helm chart
 
 Make sure you're in the correct k8s context, then:

--- a/values.yaml
+++ b/values.yaml
@@ -68,18 +68,10 @@ keycloakx:
   ##    - theme caching
   ##    - debug mode
   command:
-    - "/opt/keycloak/bin/kc.sh"
-    - "--verbose"
-    - "start"
-    - "--http-port=8080"
-    - "--hostname-strict=false"
-    - "--spi-events-listener-jboss-logging-success-level=info"
-    - "--spi-events-listener-jboss-logging-error-level=warn"
-    - "--spi-theme--static-max-age=-1"
-    - "--spi-theme--cache-themes=false"
-    - "--spi-theme--cache-templates=false"
-    - "--log-level=error"
-    - "--log-level-org.keycloak.social.user_profile_dump=debug"
+    - sh
+  args:
+    - -c
+    - "/opt/keycloak/bin/kc.sh build --vault=file && /opt/keycloak/bin/kc.sh --verbose start --http-port=8080 --hostname-strict=false --spi-events-listener-jboss-logging-success-level=info --spi-events-listener-jboss-logging-error-level=warn --spi-theme--static-max-age=-1 --spi-theme--cache-themes=false --spi-theme--cache-templates=false --log-level=error --log-level-org.keycloak.events=debug --log-level-org.keycloak.social.user_profile_dump=debug --log-level-org.keycloak.vault=trace --log-level-org.keycloak.services=info --vault-dir=/opt/keycloak/vault --optimized"
 
   ## @param keycloakx.extraEnv Additional environment variables for Keycloak
   ##
@@ -108,6 +100,9 @@ keycloakx:
     - name: themes
       persistentVolumeClaim: 
           claimName: keycloak-themes
+    - name: vault
+      secret:
+          secretName: kc-vault
 
   ## @param keycloakx.extraVolumeMounts Add additional volumes mounts, e. g. for custom themes and providers
   extraVolumeMounts: |
@@ -115,6 +110,8 @@ keycloakx:
       mountPath: /opt/keycloak/providers
     - name: themes
       mountPath: /opt/keycloak/themes
+    - name: vault
+      mountPath: /opt/keycloak/vault
 
   ingress:
     ## @param keycloakx.ingress.enabled If `true`, an Ingress is created


### PR DESCRIPTION
Uses the keycloak `vault` feature to configure provider credentials, as described in issue #14 